### PR TITLE
FIX: issue with missing icon from the settings

### DIFF
--- a/javascripts/discourse/components/banner-featured-links.gjs
+++ b/javascripts/discourse/components/banner-featured-links.gjs
@@ -59,7 +59,7 @@ export default class BannerFeaturedLinks extends Component {
 
   get links() {
     return this.featuredLinks.map((link) => {
-      if (link?.icon.length) {
+      if (link?.icon?.length) {
         link.icon = /[\w-]+/.test(link.icon)
           ? iconHTML(link.icon)
           : replaceEmoji(link.icon);

--- a/test/acceptance/banner-featured-links-test.js
+++ b/test/acceptance/banner-featured-links-test.js
@@ -4,9 +4,14 @@ import { acceptance } from "discourse/tests/helpers/qunit-helpers";
 
 const linksFixtures = [
   {
-    icon: "cog",
+    icon: "gear",
     text: "Announcement",
     url: "https://meta.discourse.org/c/announcements/67",
+    target: "_blank",
+  },
+  {
+    text: "About",
+    url: "https://meta.discourse.org/about",
     target: "_blank",
   },
   {
@@ -45,7 +50,7 @@ acceptance("Banned Featured Links", function () {
 
     assert
       .dom(".banner-featured-links__link")
-      .exists({ count: 4 }, "The banner has 3 links");
+      .exists({ count: 5 }, "The banner has 5 links");
 
     assert
       .dom(".banner-featured-links__link")


### PR DESCRIPTION
meta: https://meta.discourse.org/t/banner-featured-links/327497/9?u=arkshine

It fixes an issue when the icon is missing from the settings object.
It can happen if you edit the settings directly from the Settings Editor button and omit the `icon` field.